### PR TITLE
added travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+before_install:
+  - lsb_release -c;
+  - lsb_release -r;
+  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu quantal main universe multiverse restricted';
+  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu raring main universe multiverse restricted';
+  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu saucy main universe multiverse restricted';
+  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty main universe multiverse restricted';
+  - sudo apt-get -y update;
+
+install:
+  - sudo apt-get --no-install-recommends -y install g++;
+  - sudo apt-get --no-install-recommends -y install clang;
+  - if (clang --version | grep 'clang version 3\.3'); then
+      sudo apt-get --no-install-recommends -y install libclang-common-3.3-dev;
+    fi
+  - sudo apt-get --no-install-recommends -y install cmake;
+  - sudo apt-get -y autoremove --purge;
+# Uncomment the followint to enable coveralls support.
+#  - sudo pip install cpp-coveralls;
+
+before_script:
+  - $CXX --version;
+  - $CXX -dumpversion;
+
+script:
+  - cmake . && make && make test;
+    
+# Uncomment the following block to enable code coverage support.
+#after_success:
+#    GCOV=gcov-`$CXX -dumpversion | sed -e 's/^\([0-9]\+\.[0-9]\+\).*$/\1/'`;
+#    which $GCOV || GCOV="";
+#    echo "gcov: $GCOV";
+#    if [ ! -z "$GCOV" ]; then
+#      coveralls --gcov $GCOV --gcov-options '\-p \-l' -b . -r . -e .git
+#                 -e CMakeFiles -e docs -e /usr;
+#    fi
+
+# Use after_failure to reveal *.log files that were generated during config
+# phase and so on. We should print to console as much information as we can,
+# to quickly find the cause of a failure.
+#after_failure:
+#  - ...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 tinympl
 =======
 
+[![Build Status](https://travis-ci.org/sbabbi/tinympl.svg?branch=master)](https://travis-ci.org/sbabbi/tinympl)
+
 **Tinympl** implements some useful C++ template meta-programming algorithms. 
 Most of this work is inspired by [Boost.MPL](http://www.boost.org/doc/libs/1_55_0/libs/mpl/doc/index.html).
 Unlike Boost.MPL, this package makes use of the C++11 features, resulting in a much smaller code base.


### PR DESCRIPTION
Thee only thing that remains is to:
- go to https://travis-ci.org/,
- click SignUp with Github (top, right),
- go to accounts (top, right), 
- push the 'sync now' button and enable tinympl repo.

As you may see, the current version [doesn't seem to work with clang compiler](https://travis-ci.org/ptomulik/tinympl/builds/28068397). I'll investigate it.
