### PR TITLE
Some fixes for MSVC2013

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,143 +69,148 @@ set(TINYMPL_HEADERS
 
 add_library(tinympl STATIC ${TINYMPL_HEADERS})
 set_target_properties(tinympl PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(tinympl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 configure_file(Doxyfile.in ${CMAKE_BINARY_DIR}/Doxyfile @ONLY)
 
 install(DIRECTORY tinympl DESTINATION include)
 
-add_definitions(-std=c++11)
-add_definitions(-Wall -pedantic)
+if(NOT MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -pedantic")
+endif()
 
-add_executable(tinympl_test examples/main.cpp)
-set_target_properties(tinympl_test PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR})
+add_executable(tinympl_test_example examples/main.cpp)
+set_target_properties(tinympl_test_example PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
+add_test( tinympl_runtime tinympl_test_example )
 
-add_executable(test/test_tinympl
-       test/test_tinympl.cpp
-       test/tinympl/accumulate.cpp
-       test/tinympl/algorithm.cpp
-       test/tinympl/algorithm_variadic.cpp
-       test/tinympl/all_of.cpp
-       test/tinympl/and_b.cpp
-       test/tinympl/any_of.cpp
-       test/tinympl/as_sequence.cpp
-       test/tinympl/apply.cpp
-       test/tinympl/at.cpp
-       test/tinympl/bind.cpp
-       test/tinympl/bool.cpp
-       test/tinympl/char.cpp
-       test/tinympl/copy.cpp
-       test/tinympl/copy_if.cpp
-       test/tinympl/copy_n.cpp
-       test/tinympl/count.cpp
-       test/tinympl/count_if.cpp
-       test/tinympl/divides.cpp
-       test/tinympl/equal_to.cpp
-       test/tinympl/erase.cpp
-       test/tinympl/fill_n.cpp
-       test/tinympl/find.cpp
-       test/tinympl/find_if.cpp
-       test/tinympl/functional.cpp
-       test/tinympl/fused_map.cpp
-       test/tinympl/fused_value_map.cpp
-       test/tinympl/generate_n.cpp
-       test/tinympl/greater.cpp
-       test/tinympl/greater_equal.cpp
-       test/tinympl/identity.cpp
-       test/tinympl/if.cpp
-       test/tinympl/inherit.cpp
-       test/tinympl/insert.cpp
-       test/tinympl/int.cpp
-       test/tinympl/is_sequence.cpp
-       test/tinympl/is_unique.cpp
-       test/tinympl/join.cpp
-       test/tinympl/lambda.cpp
-       test/tinympl/left_fold.cpp
-       test/tinympl/less.cpp
-       test/tinympl/less_equal.cpp
-       test/tinympl/lexicographical_compare.cpp
-       test/tinympl/logical_and.cpp
-       test/tinympl/logical_not.cpp
-       test/tinympl/logical_or.cpp
-       test/tinympl/long.cpp
-       test/tinympl/map.cpp
-       test/tinympl/max_element.cpp
-       test/tinympl/min_element.cpp
-       test/tinympl/minus.cpp
-       test/tinympl/modulus.cpp
-       test/tinympl/multiplies.cpp
-       test/tinympl/negate.cpp
-       test/tinympl/none_of.cpp
-       test/tinympl/not_b.cpp
-       test/tinympl/not_equal_to.cpp
-       test/tinympl/or_b.cpp
-       test/tinympl/plus.cpp
-       test/tinympl/ratio.cpp
-       test/tinympl/remove.cpp
-       test/tinympl/remove_if.cpp
-       test/tinympl/replace.cpp
-       test/tinympl/replace_if.cpp
-       test/tinympl/reverse.cpp
-       test/tinympl/right_fold.cpp
-       test/tinympl/sequence.cpp
-       test/tinympl/set_difference.cpp
-       test/tinympl/set_intersection.cpp
-       test/tinympl/set_union.cpp
-       test/tinympl/short.cpp
-       test/tinympl/size.cpp
-       test/tinympl/sizeof.cpp
-       test/tinympl/sort.cpp
-       test/tinympl/string.cpp
-       test/tinympl/string_macro.cpp
-       test/tinympl/to_string.cpp
-       test/tinympl/transform.cpp
-       test/tinympl/transform2.cpp
-       test/tinympl/transform_many.cpp
-       test/tinympl/transpose.cpp
-       test/tinympl/unique.cpp
-       test/tinympl/unordered_equal.cpp
-       test/tinympl/value_map.cpp
-       test/tinympl/variadic.cpp
-       test/tinympl/variadic/accumulate.cpp
-       test/tinympl/variadic/all_of.cpp
-       test/tinympl/variadic/any_of.cpp
-       test/tinympl/variadic/at.cpp
-       test/tinympl/variadic/copy.cpp
-       test/tinympl/variadic/copy_if.cpp
-       test/tinympl/variadic/copy_n.cpp
-       test/tinympl/variadic/count.cpp
-       test/tinympl/variadic/count_if.cpp
-       test/tinympl/variadic/erase.cpp
-       test/tinympl/variadic/fill_n.cpp
-       test/tinympl/variadic/find.cpp
-       test/tinympl/variadic/find_if.cpp
-       test/tinympl/variadic/generate_n.cpp
-       test/tinympl/variadic/insert.cpp
-       test/tinympl/variadic/is_unique.cpp
-       test/tinympl/variadic/left_fold.cpp
-       test/tinympl/variadic/max_element.cpp
-       test/tinympl/variadic/min_element.cpp
-       test/tinympl/variadic/none_of.cpp
-       test/tinympl/variadic/remove.cpp
-       test/tinympl/variadic/remove_if.cpp
-       test/tinympl/variadic/replace.cpp
-       test/tinympl/variadic/replace_if.cpp
-       test/tinympl/variadic/reverse.cpp
-       test/tinympl/variadic/right_fold.cpp
-       test/tinympl/variadic/size.cpp
-       test/tinympl/variadic/sort.cpp
-       test/tinympl/variadic/transform.cpp
-       test/tinympl/variadic/unique.cpp
-       test/tinympl/vector.cpp
-       test/tinympl/zip.cpp)
+find_package(Boost COMPONENTS unit_test)
+if(BOOST_UNIT_TEST_FOUND)
+        add_executable(test_tinympl
+               test/test_tinympl.cpp
+               test/tinympl/accumulate.cpp
+               test/tinympl/algorithm.cpp
+               test/tinympl/algorithm_variadic.cpp
+               test/tinympl/all_of.cpp
+               test/tinympl/and_b.cpp
+               test/tinympl/any_of.cpp
+               test/tinympl/as_sequence.cpp
+               test/tinympl/apply.cpp
+               test/tinympl/at.cpp
+               test/tinympl/bind.cpp
+               test/tinympl/bool.cpp
+               test/tinympl/char.cpp
+               test/tinympl/copy.cpp
+               test/tinympl/copy_if.cpp
+               test/tinympl/copy_n.cpp
+               test/tinympl/count.cpp
+               test/tinympl/count_if.cpp
+               test/tinympl/divides.cpp
+               test/tinympl/equal_to.cpp
+               test/tinympl/erase.cpp
+               test/tinympl/fill_n.cpp
+               test/tinympl/find.cpp
+               test/tinympl/find_if.cpp
+               test/tinympl/functional.cpp
+               test/tinympl/fused_map.cpp
+               test/tinympl/fused_value_map.cpp
+               test/tinympl/generate_n.cpp
+               test/tinympl/greater.cpp
+               test/tinympl/greater_equal.cpp
+               test/tinympl/identity.cpp
+               test/tinympl/if.cpp
+               test/tinympl/inherit.cpp
+               test/tinympl/insert.cpp
+               test/tinympl/int.cpp
+               test/tinympl/is_sequence.cpp
+               test/tinympl/is_unique.cpp
+               test/tinympl/join.cpp
+               test/tinympl/lambda.cpp
+               test/tinympl/left_fold.cpp
+               test/tinympl/less.cpp
+               test/tinympl/less_equal.cpp
+               test/tinympl/lexicographical_compare.cpp
+               test/tinympl/logical_and.cpp
+               test/tinympl/logical_not.cpp
+               test/tinympl/logical_or.cpp
+               test/tinympl/long.cpp
+               test/tinympl/map.cpp
+               test/tinympl/max_element.cpp
+               test/tinympl/min_element.cpp
+               test/tinympl/minus.cpp
+               test/tinympl/modulus.cpp
+               test/tinympl/multiplies.cpp
+               test/tinympl/negate.cpp
+               test/tinympl/none_of.cpp
+               test/tinympl/not_b.cpp
+               test/tinympl/not_equal_to.cpp
+               test/tinympl/or_b.cpp
+               test/tinympl/plus.cpp
+               test/tinympl/ratio.cpp
+               test/tinympl/remove.cpp
+               test/tinympl/remove_if.cpp
+               test/tinympl/replace.cpp
+               test/tinympl/replace_if.cpp
+               test/tinympl/reverse.cpp
+               test/tinympl/right_fold.cpp
+               test/tinympl/sequence.cpp
+               test/tinympl/set_difference.cpp
+               test/tinympl/set_intersection.cpp
+               test/tinympl/set_union.cpp
+               test/tinympl/short.cpp
+               test/tinympl/size.cpp
+               test/tinympl/sizeof.cpp
+               test/tinympl/sort.cpp
+               test/tinympl/string.cpp
+               test/tinympl/string_macro.cpp
+               test/tinympl/to_string.cpp
+               test/tinympl/transform.cpp
+               test/tinympl/transform2.cpp
+               test/tinympl/transform_many.cpp
+               test/tinympl/transpose.cpp
+               test/tinympl/unique.cpp
+               test/tinympl/unordered_equal.cpp
+               test/tinympl/value_map.cpp
+               test/tinympl/variadic.cpp
+               test/tinympl/variadic/accumulate.cpp
+               test/tinympl/variadic/all_of.cpp
+               test/tinympl/variadic/any_of.cpp
+               test/tinympl/variadic/at.cpp
+               test/tinympl/variadic/copy.cpp
+               test/tinympl/variadic/copy_if.cpp
+               test/tinympl/variadic/copy_n.cpp
+               test/tinympl/variadic/count.cpp
+               test/tinympl/variadic/count_if.cpp
+               test/tinympl/variadic/erase.cpp
+               test/tinympl/variadic/fill_n.cpp
+               test/tinympl/variadic/find.cpp
+               test/tinympl/variadic/find_if.cpp
+               test/tinympl/variadic/generate_n.cpp
+               test/tinympl/variadic/insert.cpp
+               test/tinympl/variadic/is_unique.cpp
+               test/tinympl/variadic/left_fold.cpp
+               test/tinympl/variadic/max_element.cpp
+               test/tinympl/variadic/min_element.cpp
+               test/tinympl/variadic/none_of.cpp
+               test/tinympl/variadic/remove.cpp
+               test/tinympl/variadic/remove_if.cpp
+               test/tinympl/variadic/replace.cpp
+               test/tinympl/variadic/replace_if.cpp
+               test/tinympl/variadic/reverse.cpp
+               test/tinympl/variadic/right_fold.cpp
+               test/tinympl/variadic/size.cpp
+               test/tinympl/variadic/sort.cpp
+               test/tinympl/variadic/transform.cpp
+               test/tinympl/variadic/unique.cpp
+               test/tinympl/vector.cpp
+               test/tinympl/zip.cpp)
 
-target_include_directories(test/test_tinympl
-       PUBLIC ${CMAKE_SOURCE_DIR}
-       PUBLIC ${CMAKE_SOURCE_DIR}/test
-)
+        target_include_directories(test_tinympl
+               PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+               PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/test
+        )
 
-target_link_libraries(test/test_tinympl boost_unit_test_framework)
-set_target_properties(test/test_tinympl PROPERTIES COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK=1)
+        target_link_libraries(test_tinympl boost_unit_test_framework)
+        set_target_properties(test_tinympl PROPERTIES COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK=1)
+        add_test( new_tinympl_runtime test_tinympl )
+endif()
 
-add_test( tinympl_runtime tinympl_test )
-add_test( new_tinympl_runtime test/test_tinympl )

--- a/examples/algorithm_example.hpp
+++ b/examples/algorithm_example.hpp
@@ -1,6 +1,7 @@
 
 #include <tinympl/algorithm.hpp>
 #include <tuple>
+#include <string>
 
 namespace algorithm_example {
 

--- a/tinympl/bind.hpp
+++ b/tinympl/bind.hpp
@@ -81,7 +81,7 @@ private:
 		{
 			template<class T,class Enable = void> struct pick {typedef T type;};
 			template<class T> struct pick<T, typename std::enable_if< (is_placeholder<T>::value > 0) >::type> {typedef variadic::at_t<is_placeholder<T>::value-1, Args ... > type;};
-			template<class T> struct pick<T, typename std::enable_if< is_bind_expression<T>::type::value>::type> {typedef typename T::template eval<Args...>::type type;};
+			template<class T> struct pick<T, typename std::enable_if< is_bind_expression<T>::value >::type> {typedef typename T::template eval<Args...>::type type;};
 
 			typedef typename pick<Head>::type argument_t;
 

--- a/tinympl/variadic/at.hpp
+++ b/tinympl/variadic/at.hpp
@@ -24,11 +24,11 @@ namespace variadic {
  * \brief Extract the i-th element of a variadic template
  * \param i The index to extract
  */
-template<int i,class ... Args> struct at;
+template<std::size_t i, class ... Args> struct at;
 
-template<int i,class ... Args> using at_t = typename at<i,Args...>::type;
+template<std::size_t i, class ... Args> using at_t = typename at<i, Args...>::type;
 
-template<int i,class Head,class ... Tail> struct at<i,Head,Tail...>
+template<std::size_t i, class Head, class ... Tail> struct at<i, Head, Tail...>
 {
 	static_assert(i < sizeof ... (Tail) + 1,"Index out of range");
 	typedef typename at<i-1,Tail...>::type type;

--- a/tinympl/vector.hpp
+++ b/tinympl/vector.hpp
@@ -13,8 +13,10 @@
 #ifndef TINYMPL_VECTOR_HPP
 #define TINYMPL_VECTOR_HPP
 
-#include <tinympl/algorithm.hpp>
-#include <tinympl/sequence.hpp>
+#include <tinympl/variadic/at.hpp>
+#include <tinympl/variadic/erase.hpp>
+#include <tinympl/erase.hpp>
+#include <tinympl/insert.hpp>
 
 namespace tinympl {
 


### PR DESCRIPTION
I'm using this on MSVC2013. There are a few things it just won't be able to handle (no `constexpr` for example, so tests don't build because string blows up) but the variadic template stuff seems to fill a need and prevent me from re-writing things. These small changes let me use a chunk of the sequence stuff on VC12.
